### PR TITLE
Added RSSI sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ ble_keyboard:
   reconnect: true
   buttons: true
   use_default_libs: false
+  rssi:
+    name: "RSSI"
+    filters:
+      - filter_out: NAN
+      - sliding_window_moving_average:
+          window_size: 60
+          send_every: 60
 ```
 
 * **id** (Optional, string): Component ID. Needed for action;
@@ -75,6 +82,7 @@ ble_keyboard:
 * **reconnect** (Optional, bool): Automatic reconnect service after disconnecting the device. (default: true);
 * **buttons** (Optional, bool): Whether to add separate buttons for [keys](https://github.com/dmamontov/esphome-blekeyboard/wiki/Keys) (default: true);
 * **use_default_libs** (Optional, bool): Whether to use the arduino standard library. (default: false).
+* **rssi** (Optional, [Sensor](https://esphome.io/components/sensor/index.html)): Adds a signal strength sensor configuration. Note that it updates every seconds, so it's best to add a filter to not spam Home Assistant.
 
 ### Actions
 

--- a/components/ble_keyboard/__init__.py
+++ b/components/ble_keyboard/__init__.py
@@ -45,10 +45,12 @@ from .const import (
     CONF_RECONNECT,
     CONF_TEXT,
     CONF_USE_DEFAULT_LIBS,
+    CONF_RSSI,
     DOMAIN,
     LIBS_ADDITIONAL,
     LIBS_DEFAULT,
     NUMBERS,
+    RSSI_SENSOR_SCHEMA,
 )
 
 CODEOWNERS: Final = ["@dmamontov"]
@@ -69,6 +71,7 @@ CONFIG_SCHEMA: Final = cv.Schema(
         cv.Optional(CONF_RECONNECT, default=True): cv.boolean,
         cv.Optional(CONF_USE_DEFAULT_LIBS, default=False): cv.boolean,
         cv.Optional(CONF_BUTTONS, default=True): cv.boolean,
+        cv.Optional(CONF_RSSI): RSSI_SENSOR_SCHEMA,
     }
 )
 
@@ -97,7 +100,7 @@ async def to_code(config: dict) -> None:
 
     await adding_binary_sensors(var)
     await adding_numbers(var)
-    await adding_sensors(var)
+    await adding_sensors(var, config)
 
     if config[CONF_BUTTONS]:
         await adding_buttons(var)
@@ -159,15 +162,21 @@ async def adding_binary_sensors(var: MockObj) -> None:
         var.set_state_sensor(await binary_sensor.new_binary_sensor(BINARY_SENSOR_STATE))
     )
 
-async def adding_sensors(var: MockObj) -> None:
-    """Adding sensor
+async def adding_sensors(var: MockObj, config: dict) -> None:
+    """Adding sensors
 
     :param var: MockObj
     """
 
-    cg.add(
-        var.set_rssi_sensor(await sensor.new_sensor(RSSI_SENSOR_STATE))
-    )
+    
+    if CONF_RSSI in config:
+        cg.add(
+            var.set_rssi_sensor(await sensor.new_sensor(config[CONF_RSSI]))
+        )
+    else:
+        cg.add(
+            var.set_rssi_sensor(await sensor.new_sensor(RSSI_SENSOR_STATE))
+        )
 
 def adding_dependencies(use_default_libs: bool = True) -> None:
     """Adding dependencies

--- a/components/ble_keyboard/__init__.py
+++ b/components/ble_keyboard/__init__.py
@@ -34,7 +34,6 @@ from .const import (
     ACTION_START_CLASS,
     ACTION_STOP_CLASS,
     BINARY_SENSOR_STATE,
-    RSSI_SENSOR_STATE,
     BUILD_FLAGS,
     BUTTONS_KEY,
     COMPONENT_BUTTON_CLASS,
@@ -172,10 +171,6 @@ async def adding_sensors(var: MockObj, config: dict) -> None:
     if CONF_RSSI in config:
         cg.add(
             var.set_rssi_sensor(await sensor.new_sensor(config[CONF_RSSI]))
-        )
-    else:
-        cg.add(
-            var.set_rssi_sensor(await sensor.new_sensor(RSSI_SENSOR_STATE))
         )
 
 def adding_dependencies(use_default_libs: bool = True) -> None:

--- a/components/ble_keyboard/__init__.py
+++ b/components/ble_keyboard/__init__.py
@@ -8,7 +8,7 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
 from esphome.automation import maybe_simple_id
-from esphome.components import binary_sensor, button, number
+from esphome.components import binary_sensor, button, number, sensor
 from esphome.const import (
     CONF_BATTERY_LEVEL,
     CONF_CODE,
@@ -34,6 +34,7 @@ from .const import (
     ACTION_START_CLASS,
     ACTION_STOP_CLASS,
     BINARY_SENSOR_STATE,
+    RSSI_SENSOR_STATE,
     BUILD_FLAGS,
     BUTTONS_KEY,
     COMPONENT_BUTTON_CLASS,
@@ -51,7 +52,7 @@ from .const import (
 )
 
 CODEOWNERS: Final = ["@dmamontov"]
-AUTO_LOAD: Final = ["binary_sensor", "number", "button"]
+AUTO_LOAD: Final = ["binary_sensor", "number", "button", "sensor"]
 
 ble_keyboard_ns = cg.esphome_ns.namespace(DOMAIN)
 
@@ -96,6 +97,7 @@ async def to_code(config: dict) -> None:
 
     await adding_binary_sensors(var)
     await adding_numbers(var)
+    await adding_sensors(var)
 
     if config[CONF_BUTTONS]:
         await adding_buttons(var)
@@ -157,6 +159,15 @@ async def adding_binary_sensors(var: MockObj) -> None:
         var.set_state_sensor(await binary_sensor.new_binary_sensor(BINARY_SENSOR_STATE))
     )
 
+async def adding_sensors(var: MockObj) -> None:
+    """Adding sensor
+
+    :param var: MockObj
+    """
+
+    cg.add(
+        var.set_rssi_sensor(await sensor.new_sensor(RSSI_SENSOR_STATE))
+    )
 
 def adding_dependencies(use_default_libs: bool = True) -> None:
     """Adding dependencies

--- a/components/ble_keyboard/ble_keyboard.cpp
+++ b/components/ble_keyboard/ble_keyboard.cpp
@@ -50,7 +50,9 @@ void Esp32BleKeyboard::start() {
   pServer->startAdvertising();
 }
 
-void Esp32BleKeyboard::update() { state_sensor_->publish_state(bleKeyboard.isConnected());
+void Esp32BleKeyboard::update() {
+  state_sensor_->publish_state(bleKeyboard.isConnected());
+  if (rssi_sensor_ == nullptr) return;
   if (bleKeyboard.isConnected()) {
       std::vector<uint16_t> ids = pServer->getPeerDevices();
 

--- a/components/ble_keyboard/ble_keyboard.cpp
+++ b/components/ble_keyboard/ble_keyboard.cpp
@@ -50,7 +50,24 @@ void Esp32BleKeyboard::start() {
   pServer->startAdvertising();
 }
 
-void Esp32BleKeyboard::update() { state_sensor_->publish_state(bleKeyboard.isConnected()); }
+void Esp32BleKeyboard::update() { state_sensor_->publish_state(bleKeyboard.isConnected());
+  if (bleKeyboard.isConnected()) {
+      std::vector<uint16_t> ids = pServer->getPeerDevices();
+
+      for (uint16_t &id : ids) {
+        int8_t rssiValue = 0;
+        int rc = ble_gap_conn_rssi(id, &rssiValue);
+        if(rc != 0) {
+            ESP_LOGE(TAG, "Failed to read RSSI error code: %d (connection: %i)",
+                                    rc, id);
+        } else {
+          rssi_sensor_->publish_state(rssiValue);
+        }
+      }
+  } else {
+    rssi_sensor_->publish_state(NAN);
+  }
+}
 
 bool Esp32BleKeyboard::is_connected() {
   if (!bleKeyboard.isConnected()) {

--- a/components/ble_keyboard/ble_keyboard.h
+++ b/components/ble_keyboard/ble_keyboard.h
@@ -40,7 +40,7 @@ class Esp32BleKeyboard : public PollingComponent {
 
  protected:
   binary_sensor::BinarySensor *state_sensor_;
-  sensor::Sensor *rssi_sensor_;
+  sensor::Sensor *rssi_sensor_{nullptr};
 
  private:
   bool is_connected();

--- a/components/ble_keyboard/ble_keyboard.h
+++ b/components/ble_keyboard/ble_keyboard.h
@@ -4,6 +4,7 @@
 
 #include "esphome/core/component.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
+#include "esphome/components/sensor/sensor.h"
 #include <NimBLEServer.h>
 #include <BleKeyboard.h>
 #include <string>
@@ -27,6 +28,7 @@ class Esp32BleKeyboard : public PollingComponent {
   void set_battery_level(uint8_t level = 100) { bleKeyboard.setBatteryLevel(level); };
 
   void set_state_sensor(binary_sensor::BinarySensor *state_sensor) { state_sensor_ = state_sensor; }
+  void set_rssi_sensor(sensor::Sensor *rssi_sensor) { rssi_sensor_ = rssi_sensor; }
 
   void press(std::string message);
   void press(uint8_t key, bool with_timer = true);
@@ -38,6 +40,7 @@ class Esp32BleKeyboard : public PollingComponent {
 
  protected:
   binary_sensor::BinarySensor *state_sensor_;
+  sensor::Sensor *rssi_sensor_;
 
  private:
   bool is_connected();

--- a/components/ble_keyboard/const.py
+++ b/components/ble_keyboard/const.py
@@ -7,12 +7,13 @@ from __future__ import annotations
 from typing import Final
 
 import esphome.config_validation as cv
-from esphome.components import binary_sensor
+from esphome.components import binary_sensor, sensor
 from esphome.components.number import NumberMode
 from esphome.const import (
     CONF_DEVICE_CLASS,
     CONF_DISABLED_BY_DEFAULT,
     CONF_ENTITY_CATEGORY,
+    CONF_FORCE_UPDATE,
     CONF_ICON,
     CONF_ID,
     CONF_INITIAL_VALUE,
@@ -27,6 +28,7 @@ from esphome.const import (
     CONF_UNIT_OF_MEASUREMENT,
     CONF_VALUE,
     DEVICE_CLASS_CONNECTIVITY,
+    DEVICE_CLASS_SIGNAL_STRENGTH,
     ENTITY_CATEGORY_CONFIG,
     UNIT_MILLISECOND,
     UNIT_PERCENT,
@@ -77,6 +79,15 @@ BINARY_SENSOR_STATE: Final = {
     CONF_NAME: "Connected",
     CONF_DEVICE_CLASS: DEVICE_CLASS_CONNECTIVITY,
     CONF_DISABLED_BY_DEFAULT: False,
+}
+
+"""Sensors"""
+RSSI_SENSOR_STATE: Final = {
+    CONF_ID: cv.declare_id(sensor.Sensor)("rssi"),
+    CONF_NAME: "RSSI",
+    CONF_DEVICE_CLASS: DEVICE_CLASS_SIGNAL_STRENGTH,
+    CONF_DISABLED_BY_DEFAULT: True,
+    CONF_FORCE_UPDATE: False,
 }
 
 """Numbers"""

--- a/components/ble_keyboard/const.py
+++ b/components/ble_keyboard/const.py
@@ -95,7 +95,6 @@ RSSI_SENSOR_SCHEMA: Final = sensor.sensor_schema(
         ).extend(
             {
                 cv.Optional(CONF_NAME, default="RSSI"): cv.string,
-                cv.Optional(CONF_DISABLED_BY_DEFAULT, default=True): cv.boolean,
             }
         )
 

--- a/components/ble_keyboard/const.py
+++ b/components/ble_keyboard/const.py
@@ -30,6 +30,9 @@ from esphome.const import (
     DEVICE_CLASS_CONNECTIVITY,
     DEVICE_CLASS_SIGNAL_STRENGTH,
     ENTITY_CATEGORY_CONFIG,
+    ENTITY_CATEGORY_DIAGNOSTIC,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_DECIBEL_MILLIWATT,
     UNIT_MILLISECOND,
     UNIT_PERCENT,
 )
@@ -41,6 +44,7 @@ CONF_KEYS: Final = "keys"
 CONF_RECONNECT: Final = "reconnect"
 CONF_BUTTONS: Final = "buttons"
 CONF_USE_DEFAULT_LIBS: Final = "use_default_libs"
+CONF_RSSI: Final = "rssi"
 
 COMPONENT_CLASS: Final = "Esp32BleKeyboard"
 COMPONENT_NUMBER_CLASS: Final = "Esp32BleKeyboardNumber"
@@ -82,8 +86,21 @@ BINARY_SENSOR_STATE: Final = {
 }
 
 """Sensors"""
+RSSI_SENSOR_SCHEMA: Final = sensor.sensor_schema(
+            accuracy_decimals=0,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            state_class=STATE_CLASS_MEASUREMENT,
+            device_class=DEVICE_CLASS_SIGNAL_STRENGTH,
+            unit_of_measurement=UNIT_DECIBEL_MILLIWATT,
+        ).extend(
+            {
+                cv.Optional(CONF_NAME, default="RSSI"): cv.string,
+                cv.Optional(CONF_DISABLED_BY_DEFAULT, default=True): cv.boolean,
+            }
+        )
+
 RSSI_SENSOR_STATE: Final = {
-    CONF_ID: cv.declare_id(sensor.Sensor)("rssi"),
+    CONF_ID: cv.declare_id(sensor.Sensor)(CONF_RSSI),
     CONF_NAME: "RSSI",
     CONF_DEVICE_CLASS: DEVICE_CLASS_SIGNAL_STRENGTH,
     CONF_DISABLED_BY_DEFAULT: True,

--- a/components/ble_keyboard/const.py
+++ b/components/ble_keyboard/const.py
@@ -99,14 +99,6 @@ RSSI_SENSOR_SCHEMA: Final = sensor.sensor_schema(
             }
         )
 
-RSSI_SENSOR_STATE: Final = {
-    CONF_ID: cv.declare_id(sensor.Sensor)(CONF_RSSI),
-    CONF_NAME: "RSSI",
-    CONF_DEVICE_CLASS: DEVICE_CLASS_SIGNAL_STRENGTH,
-    CONF_DISABLED_BY_DEFAULT: True,
-    CONF_FORCE_UPDATE: False,
-}
-
 """Numbers"""
 TYPE_PRESS: Final = 0
 TYPE_RELEASE: Final = 1

--- a/examples/esp32.yaml
+++ b/examples/esp32.yaml
@@ -64,6 +64,8 @@ ble_keyboard:
   reconnect: true
   battery_level: 50
   buttons: true
+  rssi:
+    name: "RSSI"
 
 text_sensor:
   - platform: homeassistant

--- a/examples/esp32c3.yaml
+++ b/examples/esp32c3.yaml
@@ -72,6 +72,8 @@ ble_keyboard:
   reconnect: true
   battery_level: 50
   buttons: true
+  rssi:
+    name: "RSSI"
 
 text_sensor:
   - platform: homeassistant


### PR DESCRIPTION
This adds ability to add a signal strength sensor for the BLE connection (for feature request https://github.com/dmamontov/esphome-blekeyboard/issues/25). The sensor is not exposed by default and can be added via `rssi:` configuration, e.g:

```yaml
ble_keyboard:
  ...
  rssi:
    name: "RSSI"
```