### PR TITLE
Option to not advertise upon startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,45 @@ ble_keyboard:
 * **buttons** (Optional, bool): Whether to add separate buttons for [keys](https://github.com/dmamontov/esphome-blekeyboard/wiki/Keys) (default: true);
 * **use_default_libs** (Optional, bool): Whether to use the arduino standard library. (default: false).
 
+#### Controlling keyboard availability when `advertise_on_start` is `False`
+
+By default, the keyboard advertises its existence on start.  You can turn
+this off, but this creates a problem — how to ensure that the keyboard
+is available on demand?
+
+In your ESP description, you can create a switch that does exactly that:
+
+```
+globals:
+  - id: keyboard_enabled
+    type: bool
+    restore_value: no
+    initial_value: "false"
+
+switch:
+  - platform: template
+    name: Enabled
+    icon: mdi:power
+    lambda: |-
+      if (id(keyboard_enabled)) {
+        return true;
+      } else {
+        return false;
+      }
+    turn_on_action:
+      - ble_keyboard.start: le_keyboard
+      - lambda: |-
+          id(keyboard_enabled) = true;
+    turn_off_action:
+      - ble_keyboard.stop: le_keyboard
+      - lambda: |-
+          id(keyboard_enabled) = false;
+```
+
+When toggled on, the switch will start the keyboard and begin advertising
+it.  When toggled off, the keyboard will disconnect all clients and stop
+advertising — ensuring clients cannot reconnect.
+
 ### Actions
 
 #### ble_keyboard.print

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ switch:
     name: Enabled
     icon: mdi:power
     lambda: |-
-      if (id(keyboard_enabled)) {
+      return id(keyboard_enabled);
         return true;
       } else {
         return false;

--- a/README.md
+++ b/README.md
@@ -109,7 +109,9 @@ switch:
           id(keyboard_enabled) = true;
     turn_off_action:
       - ble_keyboard.stop: le_keyboard
-      - lambda: |-
+      - globals.set:
+           id: keyboard_enabled
+           value: "false"
           id(keyboard_enabled) = false;
 ```
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,9 @@ switch:
       }
     turn_on_action:
       - ble_keyboard.start: le_keyboard
-      - lambda: |-
+      - globals.set:
+           id: keyboard_enabled
+           value: "true"
           id(keyboard_enabled) = true;
     turn_off_action:
       - ble_keyboard.stop: le_keyboard

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ ble_keyboard:
   manufacturer_id: "MamonTech"
   battery_level: 50
   reconnect: true
+  advertise_on_start: true
   buttons: true
   use_default_libs: false
 ```
@@ -73,6 +74,7 @@ ble_keyboard:
 * **manufacturer_id** (Optional, string): Keyboard manufacturer (default: Esp32BleKeyboard);
 * **battery_level** (Optional, int): Keyboard battery level (default: 100);
 * **reconnect** (Optional, bool): Automatic reconnect service after disconnecting the device. (default: true);
+* **advertise_on_start** (Optional, bool): Automatic advertisement when the ESP device starts. (default: true);
 * **buttons** (Optional, bool): Whether to add separate buttons for [keys](https://github.com/dmamontov/esphome-blekeyboard/wiki/Keys) (default: true);
 * **use_default_libs** (Optional, bool): Whether to use the arduino standard library. (default: false).
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,18 @@ Custom [esphome](https://esphome.io/) component to implement a virtual BLE keybo
 
 ```yaml
 external_components:
-  - source: github://dmamontov/esphome-blekeyboard
+  - source: github://zachdekoning/esphome-blekeyboard
+```
+
+### Enable BT support (required for ESPHome 2025.10+)
+As of ESPHome 2025.10+ onwards, you must manually enable 'CONFIG_BT_ENABLED' in the framework sdkconfig_options 
+
+```yaml
+framework:
+  type: arduino
+  version: latest
+  sdkconfig_options:
+    CONFIG_BT_ENABLED: "y"
 ```
 
 ### Configuration
@@ -67,6 +78,7 @@ ble_keyboard:
   advertise_on_start: true
   buttons: true
   use_default_libs: false
+  pairing_code: 123456
 ```
 
 * **id** (Optional, string): Component ID. Needed for action;
@@ -77,6 +89,7 @@ ble_keyboard:
 * **advertise_on_start** (Optional, bool): Automatic advertisement when the ESP device starts. (default: true);
 * **buttons** (Optional, bool): Whether to add separate buttons for [keys](https://github.com/dmamontov/esphome-blekeyboard/wiki/Keys) (default: true);
 * **use_default_libs** (Optional, bool): Whether to use the arduino standard library. (default: false).
+* **pairing_code** (Optional, int): The pairing code required to be entered on the connecting device. (default: 123456).
 
 #### Controlling keyboard availability when `advertise_on_start` is `False`
 

--- a/README.md
+++ b/README.md
@@ -121,13 +121,11 @@ switch:
       - globals.set:
            id: keyboard_enabled
            value: "true"
-          id(keyboard_enabled) = true;
     turn_off_action:
       - ble_keyboard.stop: le_keyboard
       - globals.set:
            id: keyboard_enabled
            value: "false"
-          id(keyboard_enabled) = false;
 ```
 
 When toggled on, the switch will start the keyboard and begin advertising

--- a/components/ble_keyboard/__init__.py
+++ b/components/ble_keyboard/__init__.py
@@ -42,6 +42,7 @@ from .const import (
     CONF_BUTTONS,
     CONF_KEYS,
     CONF_RECONNECT,
+    CONF_ADVERTISE_ON_START,
     CONF_TEXT,
     CONF_USE_DEFAULT_LIBS,
     DOMAIN,
@@ -66,6 +67,7 @@ CONFIG_SCHEMA: Final = cv.Schema(
         cv.Optional(CONF_MANUFACTURER_ID, default=COMPONENT_CLASS): cv.Length(min=1),
         cv.Optional(CONF_BATTERY_LEVEL, default=100): cv.int_range(min=0, max=100),
         cv.Optional(CONF_RECONNECT, default=True): cv.boolean,
+        cv.Optional(CONF_ADVERTISE_ON_START, default=True): cv.boolean,
         cv.Optional(CONF_USE_DEFAULT_LIBS, default=False): cv.boolean,
         cv.Optional(CONF_BUTTONS, default=True): cv.boolean,
     }
@@ -90,6 +92,7 @@ async def to_code(config: dict) -> None:
         config[CONF_MANUFACTURER_ID],
         config[CONF_BATTERY_LEVEL],
         config[CONF_RECONNECT],
+        config[CONF_ADVERTISE_ON_START],
     )
 
     await cg.register_component(var, config)

--- a/components/ble_keyboard/__init__.py
+++ b/components/ble_keyboard/__init__.py
@@ -45,6 +45,7 @@ from .const import (
     CONF_ADVERTISE_ON_START,
     CONF_TEXT,
     CONF_USE_DEFAULT_LIBS,
+    CONF_PAIRING_CODE,
     DOMAIN,
     LIBS_ADDITIONAL,
     LIBS_DEFAULT,
@@ -70,6 +71,7 @@ CONFIG_SCHEMA: Final = cv.Schema(
         cv.Optional(CONF_ADVERTISE_ON_START, default=True): cv.boolean,
         cv.Optional(CONF_USE_DEFAULT_LIBS, default=False): cv.boolean,
         cv.Optional(CONF_BUTTONS, default=True): cv.boolean,
+        cv.Optional(CONF_PAIRING_CODE, default=123456): cv.int_range(min=0, max=999999),
     }
 )
 
@@ -93,6 +95,7 @@ async def to_code(config: dict) -> None:
         config[CONF_BATTERY_LEVEL],
         config[CONF_RECONNECT],
         config[CONF_ADVERTISE_ON_START],
+        config[CONF_PAIRING_CODE],
     )
 
     await cg.register_component(var, config)

--- a/components/ble_keyboard/__init__.py
+++ b/components/ble_keyboard/__init__.py
@@ -174,6 +174,13 @@ def adding_dependencies(use_default_libs: bool = True) -> None:
     for lib in LIBS_ADDITIONAL:  # type: ignore
         cg.add_library(*lib)
 
+    # Add updated ESP32 keyboard lib
+    cg.add_library(
+        name="ESP32 BLE Keyboard",
+        repository="https://github.com/zachdekoning/ESP32-BLE-Keyboard",
+        version=None,
+    )
+
     cg.add_build_flag(BUILD_FLAGS)
 
 

--- a/components/ble_keyboard/__init__.py
+++ b/components/ble_keyboard/__init__.py
@@ -202,6 +202,7 @@ BLEKeyboardReleaseAction = ble_keyboard_ns.class_(
     f"{DOMAIN}.release",
     BLEKeyboardReleaseAction,
     maybe_simple_id(OPERATION_BASE_SCHEMA),
+    synchronous=False
 )
 async def ble_keyboard_release_to_code(
     config: dict, action_id: ID, template_arg: TemplateArguments, args: list
@@ -231,6 +232,7 @@ BLEKeyboardPrintAction = ble_keyboard_ns.class_(ACTION_PRINT_CLASS, automation.A
             cv.Required(CONF_TEXT): cv.templatable(cv.string_strict),
         }
     ),
+    synchronous=False
 )
 async def ble_keyboard_print_to_code(
     config: dict, action_id: ID, template_arg: TemplateArguments, args: list
@@ -272,6 +274,7 @@ BLEKeyboardPressAction = ble_keyboard_ns.class_(ACTION_PRESS_CLASS, automation.A
             ),
         }
     ),
+    synchronous=False
 )
 async def ble_keyboard_press_to_code(
     config: dict, action_id: ID, template_arg: TemplateArguments, args: list
@@ -315,6 +318,7 @@ BLEKeyboardCombinationAction = ble_keyboard_ns.class_(
             ),
         }
     ),
+    synchronous=False
 )
 async def ble_keyboard_combination_to_code(
     config: dict, action_id: ID, template_arg: TemplateArguments, args: list
@@ -345,6 +349,7 @@ BLEKeyboardStartAction = ble_keyboard_ns.class_(ACTION_START_CLASS, automation.A
     f"{DOMAIN}.start",
     BLEKeyboardStartAction,
     maybe_simple_id(OPERATION_BASE_SCHEMA),
+    synchronous=False
 )
 async def ble_keyboard_start_to_code(
     config: dict, action_id: ID, template_arg: TemplateArguments, args: list
@@ -370,6 +375,7 @@ BLEKeyboardStopAction = ble_keyboard_ns.class_(ACTION_STOP_CLASS, automation.Act
     f"{DOMAIN}.stop",
     BLEKeyboardStopAction,
     maybe_simple_id(OPERATION_BASE_SCHEMA),
+    synchronous=False
 )
 async def ble_keyboard_stop_to_code(
     config: dict, action_id: ID, template_arg: TemplateArguments, args: list

--- a/components/ble_keyboard/ble_keyboard.cpp
+++ b/components/ble_keyboard/ble_keyboard.cpp
@@ -21,16 +21,21 @@ void Esp32BleKeyboard::setup() {
 
   pServer = BLEDevice::getServer();
 
-  ESP_LOGI("ble", "advertiseOnDisconnect(%s)", this->reconnect_ ? "true" : "false");
+  ESP_LOGD(TAG, "advertiseOnDisconnect(%s)", this->reconnect_ ? "true" : "false");
   pServer->advertiseOnDisconnect(this->reconnect_);
+
+  if (!this->advertise_on_start_) {
+    ESP_LOGD(TAG, "stopAdvertising()");
+    pServer->stopAdvertising();
+  }
 
   bleKeyboard.releaseAll();
 }
 
 void Esp32BleKeyboard::stop() {
-  ESP_LOGI("ble", "stop()");
+  ESP_LOGD("ble", "stop()");
   if (this->reconnect_) {
-    ESP_LOGI("ble", "advertiseOnDisconnect(false)");
+    ESP_LOGD(TAG, "advertiseOnDisconnect(false)");
     pServer->advertiseOnDisconnect(false);
   }
 
@@ -46,9 +51,9 @@ void Esp32BleKeyboard::stop() {
 }
 
 void Esp32BleKeyboard::start() {
-  ESP_LOGI("ble", "start()");
+  ESP_LOGD(TAG, "start()");
   if (this->reconnect_) {
-    ESP_LOGI("ble", "advertiseOnDisconnect(true)");
+    ESP_LOGD(TAG, "advertiseOnDisconnect(true)");
     pServer->advertiseOnDisconnect(true);
   }
 

--- a/components/ble_keyboard/ble_keyboard.cpp
+++ b/components/ble_keyboard/ble_keyboard.cpp
@@ -15,25 +15,37 @@ namespace ble_keyboard {
 static const char *const TAG = "ble_keyboard";
 
 void Esp32BleKeyboard::setup() {
-  ESP_LOGI(TAG, "Setting up...");
+  if (this->setup_) {
+    ESP_LOGW(TAG, "BLE keyboard already setup.");
+    return;
+  }
+
+  ESP_LOGCONFIG(TAG, "Setting up BLE keyboard...");
 
   bleKeyboard.begin();
 
   pServer = BLEDevice::getServer();
 
-  ESP_LOGD(TAG, "advertiseOnDisconnect(%s)", this->reconnect_ ? "true" : "false");
+  ESP_LOGCONFIG(TAG, "advertiseOnDisconnect(%s)", this->reconnect_ ? "true" : "false");
   pServer->advertiseOnDisconnect(this->reconnect_);
 
   if (!this->advertise_on_start_) {
-    ESP_LOGD(TAG, "stopAdvertising()");
+    ESP_LOGCONFIG(TAG, "stopAdvertising() because advertise_on_start is false");
     pServer->stopAdvertising();
   }
 
   bleKeyboard.releaseAll();
+  this->setup_ = true;
+  ESP_LOGCONFIG(TAG, "Finished setting up up BLE keyboard.");
 }
 
 void Esp32BleKeyboard::stop() {
-  ESP_LOGD("ble", "stop()");
+  if (!this->setup_) {
+    ESP_LOGW(TAG, "Attempting to use without setup.  Not doing anything.");
+    return;
+  }
+
+  ESP_LOGD(TAG, "stop()");
   if (this->reconnect_) {
     ESP_LOGD(TAG, "advertiseOnDisconnect(false)");
     pServer->advertiseOnDisconnect(false);
@@ -51,6 +63,10 @@ void Esp32BleKeyboard::stop() {
 }
 
 void Esp32BleKeyboard::start() {
+  if (!this->setup_) {
+    ESP_LOGW(TAG, "Attempting to use without setup.  Not doing anything.");
+    return;
+  }
   ESP_LOGD(TAG, "start()");
   if (this->reconnect_) {
     ESP_LOGD(TAG, "advertiseOnDisconnect(true)");
@@ -78,6 +94,10 @@ void Esp32BleKeyboard::update_timer() {
 }
 
 void Esp32BleKeyboard::press(std::string message) {
+  if (!this->setup_) {
+    ESP_LOGW(TAG, "Attempting to use without setup.  Not doing anything.");
+    return;
+  }
   if (this->is_connected()) {
     if (message.length() >= 5) {
       for (unsigned i = 0; i < message.length(); i += 5) {
@@ -94,6 +114,10 @@ void Esp32BleKeyboard::press(std::string message) {
 }
 
 void Esp32BleKeyboard::press(uint8_t key, bool with_timer) {
+  if (!this->setup_) {
+    ESP_LOGW(TAG, "Attempting to use without setup.  Not doing anything.");
+    return;
+  }
   if (this->is_connected()) {
     if (with_timer) {
       this->update_timer();
@@ -104,6 +128,10 @@ void Esp32BleKeyboard::press(uint8_t key, bool with_timer) {
 }
 
 void Esp32BleKeyboard::press(MediaKeyReport key, bool with_timer) {
+  if (!this->setup_) {
+    ESP_LOGW(TAG, "Attempting to use without setup.  Not doing anything.");
+    return;
+  }
   if (this->is_connected()) {
     if (with_timer) {
       this->update_timer();
@@ -113,6 +141,10 @@ void Esp32BleKeyboard::press(MediaKeyReport key, bool with_timer) {
 }
 
 void Esp32BleKeyboard::release() {
+  if (!this->setup_) {
+    ESP_LOGW(TAG, "Attempting to use without setup.  Not doing anything.");
+    return;
+  }
   if (this->is_connected()) {
     this->cancel_timeout((const std::string) TAG);
     bleKeyboard.releaseAll();

--- a/components/ble_keyboard/ble_keyboard.cpp
+++ b/components/ble_keyboard/ble_keyboard.cpp
@@ -21,13 +21,16 @@ void Esp32BleKeyboard::setup() {
 
   pServer = BLEDevice::getServer();
 
+  ESP_LOGI("ble", "advertiseOnDisconnect(%s)", this->reconnect_ ? "true" : "false");
   pServer->advertiseOnDisconnect(this->reconnect_);
 
   bleKeyboard.releaseAll();
 }
 
 void Esp32BleKeyboard::stop() {
+  ESP_LOGI("ble", "stop()");
   if (this->reconnect_) {
+    ESP_LOGI("ble", "advertiseOnDisconnect(false)");
     pServer->advertiseOnDisconnect(false);
   }
 
@@ -43,7 +46,9 @@ void Esp32BleKeyboard::stop() {
 }
 
 void Esp32BleKeyboard::start() {
+  ESP_LOGI("ble", "start()");
   if (this->reconnect_) {
+    ESP_LOGI("ble", "advertiseOnDisconnect(true)");
     pServer->advertiseOnDisconnect(true);
   }
 

--- a/components/ble_keyboard/ble_keyboard.cpp
+++ b/components/ble_keyboard/ble_keyboard.cpp
@@ -24,11 +24,14 @@ void Esp32BleKeyboard::setup() {
 
   bleKeyboard.begin();
 
-  // Set security settings for bonding so iPad will properly reconnect on device reboot
+  // Set security settings for bonding so phones/tablets will properly reconnect on device reboot
   NimBLEDevice::setSecurityAuth(true, true, true);
-  NimBLEDevice::setSecurityPasskey(123456);
+  NimBLEDevice::setSecurityPasskey(this->pairing_code_);
   NimBLEDevice::setSecurityIOCap(BLE_HS_IO_DISPLAY_ONLY);
   NimBLEDevice::setSecurityInitKey(3);
+
+  // Set BLE Tx power to max to prevent disconnects
+  NimBLEDevice::setPower(ESP_PWR_LVL_P9, NimBLETxPowerType::All);
 
   pServer = BLEDevice::getServer();
 

--- a/components/ble_keyboard/ble_keyboard.cpp
+++ b/components/ble_keyboard/ble_keyboard.cpp
@@ -24,6 +24,12 @@ void Esp32BleKeyboard::setup() {
 
   bleKeyboard.begin();
 
+  // Set security settings for bonding so iPad will properly reconnect on device reboot
+  NimBLEDevice::setSecurityAuth(true, true, true);
+  NimBLEDevice::setSecurityPasskey(123456);
+  NimBLEDevice::setSecurityIOCap(BLE_HS_IO_DISPLAY_ONLY);
+  NimBLEDevice::setSecurityInitKey(3);
+
   pServer = BLEDevice::getServer();
 
   ESP_LOGCONFIG(TAG, "advertiseOnDisconnect(%s)", this->reconnect_ ? "true" : "false");

--- a/components/ble_keyboard/ble_keyboard.cpp
+++ b/components/ble_keyboard/ble_keyboard.cpp
@@ -27,7 +27,8 @@ void Esp32BleKeyboard::setup() {
   // Set security settings for bonding so phones/tablets will properly reconnect on device reboot
   NimBLEDevice::setSecurityAuth(true, true, true);
   NimBLEDevice::setSecurityPasskey(this->pairing_code_);
-  NimBLEDevice::setSecurityIOCap(BLE_HS_IO_DISPLAY_ONLY);
+  // Indicate to peer device that there is no way to confirm a pairing code.
+  NimBLEDevice::setSecurityIOCap(BLE_HS_IO_NO_INPUT_OUTPUT);
   NimBLEDevice::setSecurityInitKey(3);
 
   // Set BLE Tx power to max to prevent disconnects

--- a/components/ble_keyboard/ble_keyboard.cpp
+++ b/components/ble_keyboard/ble_keyboard.cpp
@@ -98,8 +98,8 @@ bool Esp32BleKeyboard::is_connected() {
 }
 
 void Esp32BleKeyboard::update_timer() {
-  this->cancel_timeout((const std::string) TAG);
-  this->set_timeout((const std::string) TAG, release_delay_, [this]() { this->release(); });
+  this->cancel_timeout(TAG);
+  this->set_timeout(TAG, release_delay_, [this]() { this->release(); });
 }
 
 void Esp32BleKeyboard::press(std::string message) {
@@ -155,7 +155,7 @@ void Esp32BleKeyboard::release() {
     return;
   }
   if (this->is_connected()) {
-    this->cancel_timeout((const std::string) TAG);
+    this->cancel_timeout(TAG);
     bleKeyboard.releaseAll();
   }
 }

--- a/components/ble_keyboard/ble_keyboard.h
+++ b/components/ble_keyboard/ble_keyboard.h
@@ -12,7 +12,8 @@ namespace esphome {
 namespace ble_keyboard {
 class Esp32BleKeyboard : public PollingComponent {
  public:
-  Esp32BleKeyboard(std::string name, std::string manufacturer_id, uint8_t battery_level, bool reconnect, bool advertise_on_start)
+  Esp32BleKeyboard(std::string name, std::string manufacturer_id, uint8_t battery_level, bool reconnect,
+                   bool advertise_on_start)
       : PollingComponent(1000), bleKeyboard(name, manufacturer_id, battery_level) {
     reconnect_ = reconnect;
     advertise_on_start_ = advertise_on_start;
@@ -47,6 +48,7 @@ class Esp32BleKeyboard : public PollingComponent {
   BLEServer *pServer;
   BleKeyboard bleKeyboard;
 
+  bool setup_{false};
   bool reconnect_{true};
   bool advertise_on_start_{true};
   uint32_t default_delay_{100};

--- a/components/ble_keyboard/ble_keyboard.h
+++ b/components/ble_keyboard/ble_keyboard.h
@@ -12,9 +12,10 @@ namespace esphome {
 namespace ble_keyboard {
 class Esp32BleKeyboard : public PollingComponent {
  public:
-  Esp32BleKeyboard(std::string name, std::string manufacturer_id, uint8_t battery_level, bool reconnect)
+  Esp32BleKeyboard(std::string name, std::string manufacturer_id, uint8_t battery_level, bool reconnect, bool advertise_on_start)
       : PollingComponent(1000), bleKeyboard(name, manufacturer_id, battery_level) {
     reconnect_ = reconnect;
+    advertise_on_start_ = advertise_on_start;
   }
 
   void setup() override;
@@ -47,6 +48,7 @@ class Esp32BleKeyboard : public PollingComponent {
   BleKeyboard bleKeyboard;
 
   bool reconnect_{true};
+  bool advertise_on_start_{true};
   uint32_t default_delay_{100};
   uint32_t release_delay_{8};
 };

--- a/components/ble_keyboard/ble_keyboard.h
+++ b/components/ble_keyboard/ble_keyboard.h
@@ -13,10 +13,11 @@ namespace ble_keyboard {
 class Esp32BleKeyboard : public PollingComponent {
  public:
   Esp32BleKeyboard(std::string name, std::string manufacturer_id, uint8_t battery_level, bool reconnect,
-                   bool advertise_on_start)
+                   bool advertise_on_start, uint32_t pairing_code)
       : PollingComponent(1000), bleKeyboard(name, manufacturer_id, battery_level) {
     reconnect_ = reconnect;
     advertise_on_start_ = advertise_on_start;
+    pairing_code_ = pairing_code;
   }
 
   void setup() override;
@@ -51,6 +52,7 @@ class Esp32BleKeyboard : public PollingComponent {
   bool setup_{false};
   bool reconnect_{true};
   bool advertise_on_start_{true};
+  uint32_t pairing_code_{123456};
   uint32_t default_delay_{100};
   uint32_t release_delay_{8};
 };

--- a/components/ble_keyboard/const.py
+++ b/components/ble_keyboard/const.py
@@ -37,6 +37,7 @@ DOMAIN: Final = "ble_keyboard"
 CONF_TEXT: Final = "text"
 CONF_KEYS: Final = "keys"
 CONF_RECONNECT: Final = "reconnect"
+CONF_ADVERTISE_ON_START: Final = "advertise_on_start"
 CONF_BUTTONS: Final = "buttons"
 CONF_USE_DEFAULT_LIBS: Final = "use_default_libs"
 

--- a/components/ble_keyboard/const.py
+++ b/components/ble_keyboard/const.py
@@ -60,7 +60,7 @@ LIBS_DEFAULT: Final = [
 LIBS_ADDITIONAL: Final = [
     (
         "h2zero/NimBLE-Arduino",
-        "1.4.0",
+        "1.4.1",
         None,
     ),
     (

--- a/components/ble_keyboard/const.py
+++ b/components/ble_keyboard/const.py
@@ -40,6 +40,7 @@ CONF_RECONNECT: Final = "reconnect"
 CONF_ADVERTISE_ON_START: Final = "advertise_on_start"
 CONF_BUTTONS: Final = "buttons"
 CONF_USE_DEFAULT_LIBS: Final = "use_default_libs"
+CONF_PAIRING_CODE: Final = "pairing_code"
 
 COMPONENT_CLASS: Final = "Esp32BleKeyboard"
 COMPONENT_NUMBER_CLASS: Final = "Esp32BleKeyboardNumber"

--- a/components/ble_keyboard/const.py
+++ b/components/ble_keyboard/const.py
@@ -60,14 +60,9 @@ LIBS_DEFAULT: Final = [
 LIBS_ADDITIONAL: Final = [
     (
         "h2zero/NimBLE-Arduino",
-        "1.4.3",
+        "2.3.0",
         None,
-    ),
-    (
-        "t-vk/ESP32 BLE Keyboard",
-        "0.3.2",
-        None,
-    ),
+    )
 ]
 
 BUILD_FLAGS: Final = "-D USE_NIMBLE"

--- a/components/ble_keyboard/const.py
+++ b/components/ble_keyboard/const.py
@@ -60,7 +60,7 @@ LIBS_DEFAULT: Final = [
 LIBS_ADDITIONAL: Final = [
     (
         "h2zero/NimBLE-Arduino",
-        "1.4.1",
+        "2.3.6",
         None,
     ),
     (

--- a/components/ble_keyboard/const.py
+++ b/components/ble_keyboard/const.py
@@ -60,7 +60,7 @@ LIBS_DEFAULT: Final = [
 LIBS_ADDITIONAL: Final = [
     (
         "h2zero/NimBLE-Arduino",
-        "2.3.6",
+        "1.4.3",
         None,
     ),
     (


### PR DESCRIPTION
With some devices, it is preferable simply not to advertise at all the return of the ESP keyboard once it restarts.

This option enables users to choose that.

They can create a switch to turn advertisements off in this way:

```
globals:
  - id: keyboard_enabled
    type: bool
    restore_value: no
    initial_value: "false"

switch:
  - platform: template
    name: Enabled
    icon: mdi:power
    lambda: |-
      if (id(keyboard_enabled)) {
        return true;
      } else {
        return false;
      }
    turn_on_action:
      - ble_keyboard.start: le_keyboard
      - lambda: |-
          id(keyboard_enabled) = true;
      - logger.log:
          format: "The keyboard has been enabled."
          level: INFO
    turn_off_action:
      - ble_keyboard.stop: le_keyboard
      - lambda: |-
          id(keyboard_enabled) = false;
      - logger.log:
          format: "The keyboard has been disabled."
          level: INFO
```