### PR TITLE
Update ble_keyboard.cpp to release keys (issue #31)

### DIFF
--- a/components/ble_keyboard/ble_keyboard.cpp
+++ b/components/ble_keyboard/ble_keyboard.cpp
@@ -99,6 +99,8 @@ void Esp32BleKeyboard::press(MediaKeyReport key, bool with_timer) {
       this->update_timer();
     }
     bleKeyboard.press(key);
+	   delay(100);
+    bleKeyboard.release(key);
   }
 }
 


### PR DESCRIPTION
As per issue #31 the media keys don't get released. This is just a PR echoing @Sr-psycho fix.