### PR TITLE
make press() hold until release is called

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,27 @@ ble_keyboard.press:
 
 #### ble_keyboard.release
 
-Release keys.
+Release all keys.
 
 ```yaml
-ble_keyboard.release: my_ble_keyboard
+ble_keyboard.release: 
+  id: my_ble_keyboard
+```
+
+Release a specific Key
+```yaml
+ble_keyboard.release
+  id: my_ble_keyboard
+  code: 0x80
+```
+
+Release a specific media Key
+```yaml
+ble_keyboard.release
+  id: my_ble_keyboard
+  code: 
+    - 0
+    - 1
 ```
 
 #### ble_keyboard.combination

--- a/components/ble_keyboard/automation.h
+++ b/components/ble_keyboard/automation.h
@@ -31,7 +31,7 @@ template<typename... Ts> class Esp32BleKeyboardPressAction : public Action<Ts...
 
       this->ble_keyboard_->press(mediaKey);
     } else {
-      this->ble_keyboard_->press(this->code_.value(x...));
+      this->ble_keyboard_->press(this->code_.value(x...), false);
     }
   }
 

--- a/components/ble_keyboard/automation.h
+++ b/components/ble_keyboard/automation.h
@@ -45,10 +45,22 @@ template<typename... Ts> class Esp32BleKeyboardPressAction : public Action<Ts...
 template<typename... Ts> class Esp32BleKeyboardReleaseAction : public Action<Ts...> {
  public:
   explicit Esp32BleKeyboardReleaseAction(Esp32BleKeyboard *ble_keyboard) : ble_keyboard_(ble_keyboard) {}
+  TEMPLATABLE_VALUE(uint8_t, code)
+  
+  void play(Ts... x) override {    
+    if(keys_.size() > 1) {
+      MediaKeyReport mediaKey = {keys_[0], keys_[1]};
 
-  void play(Ts... x) override { this->ble_keyboard_->release(); }
+      this->ble_keyboard_->release(mediaKey);
+    } else {
+      this->ble_keyboard_->release(this->code_.value(x...));
+    }
+  }
+
+  void set_keys(const std::vector<uint8_t> &keys) { keys_ = keys; }
 
  protected:
+  std::vector<uint8_t> keys_;
   Esp32BleKeyboard *ble_keyboard_;
 };
 

--- a/components/ble_keyboard/ble_keyboard.cpp
+++ b/components/ble_keyboard/ble_keyboard.cpp
@@ -99,6 +99,8 @@ void Esp32BleKeyboard::press(MediaKeyReport key, bool with_timer) {
       this->update_timer();
     }
     bleKeyboard.press(key);
+      delay(100);
+    bleKeyboard.release(key);
   }
 }
 

--- a/components/ble_keyboard/ble_keyboard.cpp
+++ b/components/ble_keyboard/ble_keyboard.cpp
@@ -99,7 +99,7 @@ void Esp32BleKeyboard::press(MediaKeyReport key, bool with_timer) {
       this->update_timer();
     }
     bleKeyboard.press(key);
-      delay(100);
+      delay(8);
     bleKeyboard.release(key);
   }
 }

--- a/components/ble_keyboard/ble_keyboard.cpp
+++ b/components/ble_keyboard/ble_keyboard.cpp
@@ -99,8 +99,6 @@ void Esp32BleKeyboard::press(MediaKeyReport key, bool with_timer) {
       this->update_timer();
     }
     bleKeyboard.press(key);
-      delay(8);
-    bleKeyboard.release(key);
   }
 }
 
@@ -110,6 +108,21 @@ void Esp32BleKeyboard::release() {
     bleKeyboard.releaseAll();
   }
 }
+
+void Esp32BleKeyboard::release(uint8_t key) {
+  if(this->is_connected()) {
+    this->cancel_timeout((const std::string) TAG);
+    bleKeyboard.release(key);
+  }
+}
+
+void Esp32BleKeyboard::release(MediaKeyReport key) {
+  if(this->is_connected()) {
+    this->cancel_timeout((const std::string) TAG);
+    bleKeyboard.release(key);
+  }
+}
+
 }  // namespace ble_keyboard
 }  // namespace esphome
 

--- a/components/ble_keyboard/ble_keyboard.h
+++ b/components/ble_keyboard/ble_keyboard.h
@@ -31,6 +31,8 @@ class Esp32BleKeyboard : public PollingComponent {
   void press(std::string message);
   void press(uint8_t key, bool with_timer = true);
   void press(MediaKeyReport key, bool with_timer = true);
+  void release(uint8_t key);
+  void release(MediaKeyReport key);
   void release();
 
   void start();

--- a/components/ble_keyboard/const.py
+++ b/components/ble_keyboard/const.py
@@ -53,7 +53,7 @@ ACTION_COMBINATION_CLASS: Final = "Esp32BleKeyboardCombinationAction"
 
 """Libraries"""
 LIBS_DEFAULT: Final = [
-    ("ESP32 BLE Arduino", "1.0.1", None),
+    ("ESP32 BLE Arduino", "1.0.2", None),
 ]
 
 LIBS_ADDITIONAL: Final = [


### PR DESCRIPTION
resolves #18 , otherwise .press() always releases immidiately

## Summary by Sourcery

Bug Fixes:
- Prevent press() from immediately releasing by passing holdUntilRelease flag to press().